### PR TITLE
Add gps_umd package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "suitesparse"]
 	path = suitesparse
 	url = git@github.com:ethz-asl/suitesparse.git
-[submodule "catkin_zeromq"]
-	path = catkin_zeromq
-	url = git@github.com:ethz-asl/catkin_zeromq.git
 [submodule "catkin_poco"]
 	path = catkin_poco
 	url = git@github.com:ethz-asl/catkin_poco.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "benchmark_catkin"]
 	path = benchmark_catkin
 	url = git@github.com:ethz-asl/benchmark_catkin.git
+[submodule "gps_umd"]
+	path = gps_umd
+	url = git@github.com:ethz-asl/gps_umd.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,12 +13,6 @@
 [submodule "suitesparse"]
 	path = suitesparse
 	url = git@github.com:ethz-asl/suitesparse.git
-[submodule "catkin_poco"]
-	path = catkin_poco
-	url = git@github.com:ethz-asl/catkin_poco.git
-[submodule "poco_catkin"]
-	path = poco_catkin
-	url = git@github.com:ethz-asl/poco_catkin.git
 [submodule "zeromq_catkin"]
 	path = zeromq_catkin
 	url = git@github.com:ethz-asl/zeromq_catkin.git


### PR DESCRIPTION
The gps_umd submodule is pointing to the [gps_common_only](https://github.com/ethz-asl/gps_umd/tree/gps_common_only) branch which ignores the two other packages in that repo.

Also the following bug fixes were necessary because the jenkins git plugin doesn't accept trash in the `.gitmodules` file anymore :
 * remove catkin_zeromq 
 * remove poco_catkin and catkin_poco

FYI: @hitimo @magehrig @eggerk @fmina