### PR TITLE
Move evaluation tools into dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,3 +83,6 @@
 [submodule "internal/linter"]
 	path = internal/linter
 	url = https://github.com/ethz-asl/linter.git
+[submodule "internal/evaluation_tools"]
+	path = internal/evaluation_tools
+	url = https://github.com/ethz-asl/evaluation_tools.git


### PR DESCRIPTION
After merging this, I'll remove the submodule from within maplab and move the maplab_evaluation package out of experimental