### PR TITLE
Removed evaluation tools again from dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,6 +83,3 @@
 [submodule "internal/linter"]
 	path = internal/linter
 	url = https://github.com/ethz-asl/linter.git
-[submodule "internal/evaluation_tools"]
-	path = internal/evaluation_tools
-	url = https://github.com/ethz-asl/evaluation_tools.git


### PR DESCRIPTION
Move again into maplab because evaluation_tools depend on aslam. 