### PR TITLE
use https instead of ssl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,4 +90,4 @@
 	url = git@github.com:ethz-asl/arl_apriltags2_ros.git
 [submodule "internal/maplab_tools"]
 	path = internal/maplab_tools
-	url = git@github.com:ethz-asl/maplab_tools.git
+	url = https://github.com/ethz-asl/maplab_tools.git


### PR DESCRIPTION
`maplab_tools` was included through ssl, all others in https which makes CI much easier